### PR TITLE
Format the output of tophelpers in tabular form + adding logback + utility message templates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,10 @@ dependencies {
     implementation 'com.google.googlejavaformat:google-java-format:1.10.0'
     implementation 'com.github.freva:ascii-table:1.2.0'
 
+    implementation 'ch.qos.logback:logback-core:1.2.3'
+    implementation 'org.slf4j:slf4j-api:1.7.30'
+    runtimeOnly 'ch.qos.logback:logback-classic:1.2.3'
+
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
 }

--- a/src/main/java/gg/discord/tj/bot/command/impl/TagListCommand.java
+++ b/src/main/java/gg/discord/tj/bot/command/impl/TagListCommand.java
@@ -13,11 +13,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static gg.discord.tj.bot.util.MessageTemplate.TAGLIST_MESSAGE_TEMPLATE;
+
 public class TagListCommand
     implements Command
 {
     private static final int NO_OF_DISPLAY_COLUMNS = 3;
-    private static final String MESSAGE_TEMPLATE = "All available tags:\n```\n%s\n```";
 
     @Override
     public String getName()
@@ -48,7 +49,7 @@ public class TagListCommand
             displayDataArray[i++ % noOfDisplayRows][i % noOfDisplayRows == 0 ? j++ : j] = tag;
         }
         Objects.requireNonNull(context.getMessage().getChannel().block())
-                .createMessage(String.format(MESSAGE_TEMPLATE, AsciiTable.getTable(
+                .createMessage(String.format(TAGLIST_MESSAGE_TEMPLATE, AsciiTable.getTable(
                         AsciiTable.NO_BORDERS, columns, displayDataArray)))
                 .block();
     }

--- a/src/main/java/gg/discord/tj/bot/core/TJBot.java
+++ b/src/main/java/gg/discord/tj/bot/core/TJBot.java
@@ -31,7 +31,6 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.file.Path;
@@ -48,7 +47,7 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static gg.discord.tj.bot.util.MessageTemplate.PAINTEXT_MESSAGE_TEMPLATE;
+import static gg.discord.tj.bot.util.MessageTemplate.PLAINTEXT_MESSAGE_TEMPLATE;
 
 @SuppressWarnings("ConstantConditions")
 @RequiredArgsConstructor
@@ -192,10 +191,10 @@ public class TJBot
                 var columnData = List.<ColumnData<List<String>>>of(
                         new Column().with(row -> row.get(0)),
                         new Column().header("Name").dataAlign(HorizontalAlign.LEFT).with(row -> row.get(1)),
-                        new Column().header("Msg Count(last 30 days)").with(row -> row.get(2))
+                        new Column().header("Message Count (in the last 30 days)").with(row -> row.get(2))
                 );
                 var message = String.format(
-                        PAINTEXT_MESSAGE_TEMPLATE,
+                        PLAINTEXT_MESSAGE_TEMPLATE,
                         topHelpersList.isEmpty() ? NO_ENTRIES : AsciiTable.getTable(characters, topHelpersList, columnData)
                 );
                 e.getInteractionResponse().createFollowupMessage(message).block();

--- a/src/main/java/gg/discord/tj/bot/util/MessageTemplate.java
+++ b/src/main/java/gg/discord/tj/bot/util/MessageTemplate.java
@@ -1,0 +1,12 @@
+package gg.discord.tj.bot.util;
+
+public final class MessageTemplate {
+    public static final String PAINTEXT_MESSAGE_TEMPLATE = "```\n%s\n```";
+    public static final String JAVA_MESSAGE_TEMPLATE = "```java\n%s\n```";
+    public static final String KOTLIN_MESSAGE_TEMPLATE = "```kotlin\n%s\n```";
+    public static final String SQL_MESSAGE_TEMPLATE = "```sql\n%s\n```";
+    public static final String SHELL_MESSAGE_TEMPLATE = "```shell\n%s\n```";
+    public static final String JAVASCRIPT_MESSAGE_TEMPLATE = "```javascript\n%s\n```";
+
+    public static final String TAGLIST_MESSAGE_TEMPLATE = "All available tags:\n" + PAINTEXT_MESSAGE_TEMPLATE;
+}

--- a/src/main/java/gg/discord/tj/bot/util/MessageTemplate.java
+++ b/src/main/java/gg/discord/tj/bot/util/MessageTemplate.java
@@ -1,12 +1,12 @@
 package gg.discord.tj.bot.util;
 
 public final class MessageTemplate {
-    public static final String PAINTEXT_MESSAGE_TEMPLATE = "```\n%s\n```";
+    public static final String PLAINTEXT_MESSAGE_TEMPLATE = "```\n%s\n```";
     public static final String JAVA_MESSAGE_TEMPLATE = "```java\n%s\n```";
     public static final String KOTLIN_MESSAGE_TEMPLATE = "```kotlin\n%s\n```";
     public static final String SQL_MESSAGE_TEMPLATE = "```sql\n%s\n```";
     public static final String SHELL_MESSAGE_TEMPLATE = "```shell\n%s\n```";
     public static final String JAVASCRIPT_MESSAGE_TEMPLATE = "```javascript\n%s\n```";
 
-    public static final String TAGLIST_MESSAGE_TEMPLATE = "All available tags:\n" + PAINTEXT_MESSAGE_TEMPLATE;
+    public static final String TAGLIST_MESSAGE_TEMPLATE = "All available tags:\n" + PLAINTEXT_MESSAGE_TEMPLATE;
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
The primary goal of this PR is to format the output of `/tophelpers` in a tabular form. As a part of the task, additional application side transformations were delegated to native SQL

Current output of the command:
```
#1 Zabuzard#3452 - 3328 messages in help channels in the last 30 days
#2 Alathreon [3824 - 9095 - 9308]#8051 - 2929 messages in help channels in the last 30 days
#3 illuminator3#0001 - 2487 messages in help channels in the last 30 days
#4 borgrel#7091 - 1403 messages in help channels in the last 30 days
#5 emccue#1975 - 1294 messages in help channels in the last 30 days
#6 dhrubajyoti_g#1718 - 786 messages in help channels in the last 30 days
#7 D4FuQ#5130 - 721 messages in help channels in the last 30 days
#8 Hayden#7709 - 659 messages in help channels in the last 30 days
#9 ericmp#6201 - 562 messages in help channels in the last 30 days
```

Output after changes:
```
    | Name                                | Msg Count(last 30 days) 
----+-------------------------------------+-------------------------
  1 | Zabuzard#3452                       |                    4878 
  2 | Alathreon [3824 - 9095 - 9308]#8051 |                    3600 
  3 | illuminator3#0001                   |                    3271 
  4 | borgrel#7091                        |                    1440 
  5 | emccue#1975                         |                    1371 
  6 | thenotsoOP#7288                     |                    1346 
  7 | dhrubajyoti_g#1718                  |                    1078 
  8 | Silk#6031                           |                     997 
  9 | doctorpangloss#6014                 |                     838 
 10 | D4FuQ#5130                          |                     768 
```

PS: Ignore the differences in msg count as these were from 2 different environments